### PR TITLE
Return 0 in common.DemoHeader.FrameTime if PlaybackFrames is 0 to avoid dividing by zero

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -42,6 +42,9 @@ func (h DemoHeader) FrameRate() float64 {
 
 // FrameTime returns the time a frame / demo-tick takes in seconds.
 func (h DemoHeader) FrameTime() time.Duration {
+	if h.PlaybackFrames == 0 {
+		return 0
+	}
 	return time.Duration(h.PlaybackTime.Nanoseconds() / int64(h.PlaybackFrames))
 }
 


### PR DESCRIPTION
See #108